### PR TITLE
Update button rendering to use our own compliant visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The lists below only apply to version 3 of the VT specification. There are 3 sta
 - :green_circle: Container
 - :white_circle: SoftKeyMask
 - :yellow_circle: Key
-- :yellow_circle: Button
+- :green_circle: Button
 - :white_circle: InputBoolean
 - :white_circle: InputString
 - :white_circle: InputNumber


### PR DESCRIPTION
Reworked the visuals of the button to be compliant with the standard, at least for the version 3 specification. Though I also attempted to make it compliant with the other version by adding a version parameter that we can use later on. 

Finally I replaced the deprecated method `allocate_ui_at_rect` with the new `allocate_new_ui`