### PR TITLE
Ability to rename objects via double click or object context menu

### DIFF
--- a/src/object_info.rs
+++ b/src/object_info.rs
@@ -35,6 +35,13 @@ impl ObjectInfo {
         }
     }
 
+    /// Set the name of the object.
+    pub fn set_name(&mut self, name: String) {
+        if !name.is_empty() {
+            self.name = Some(name);
+        }
+    }
+
     pub fn get_unique_id(&self) -> Uuid {
         self.unique_id
     }


### PR DESCRIPTION
With this PR we allow users to give objects custom names, the name is then saved inside the previously created `ObjectInfo` struct that keeps track of all information not applicable to the standards' definition of the object pool