### PR TITLE
Add rendering for auxiliary objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ The lists below only apply to version 3 of the VT specification. There are 3 sta
 - :white_circle: OutputArchedBarGraph
 - :green_circle: PictureGraphic
 - :green_circle: ObjectPointer
-- :white_circle: Auxiliary Function Type 2
-- :white_circle: Auxiliary Input Type 2
-- :white_circle: Auxiliary Control Designator Type 2 Object Pointer
+- :yellow_circle: Auxiliary Function Type 2
+- :yellow_circle: Auxiliary Input Type 2
+- :yellow_circle: Auxiliary Control Designator Type 2 Object Pointer
 
 
 ## Installation


### PR DESCRIPTION
This pull request implements rendering support for "Type 2" Auxiliary objects in the UI and updates their status in the documentation. The most significant changes are the addition of rendering logic for `AuxiliaryFunctionType2`, `AuxiliaryInputType2`, and `AuxiliaryControlDesignatorType2` objects, as well as improvements to how object references are rendered in the UI.

### Rendering support for Type 2 Auxiliary objects

* Implemented rendering for `AuxiliaryFunctionType2` and `AuxiliaryInputType2` objects, including drawing their background color and rendering their child object references. (`src/object_rendering.rs`)
* Implemented rendering for `AuxiliaryControlDesignatorType2`, handling all pointer types according to the VT specification, with placeholders for cases where runtime assignment info is not available. (`src/object_rendering.rs`)

### UI rendering improvements

* Updated the rendering of `Key` objects to use `egui::Vec2::INFINITY` for sizing, preparing for dynamic softkey area sizing. (`src/object_rendering.rs`)

### Documentation updates

* Updated the status of "Type 2" Auxiliary objects in the `README.md` from "not implemented" (white circle) to "in progress/partial" (yellow circle), reflecting the new rendering support. (`README.md`)

### Code cleanup

* Removed an early return in `WorkingSet::render` that previously prevented rendering if the object was not selectable, allowing for more flexible rendering logic. (`src/object_rendering.rs`)